### PR TITLE
feat(b1): Implement capabilities check and upfront validation

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -12,8 +12,15 @@ pub use errors::VulkanRError;
 /// Get GPU information
 #[cfg_attr(feature = "ffi", extendr)]
 fn gpu_info() -> Result<String, VulkanRError> {
-    let renderer = WgpuRenderer::new()?;
-    Ok(renderer.get_info())
+    let r = WgpuRenderer::new()?;
+    Ok(format!(
+        "Backend: {backend}; Device: {name}; max_tex_2d: {mt2d}; max_bind_groups: {bg}; budget_mb: {mb}",
+        backend = r.get_backend_name(),
+        name = r.get_device_name(),
+        mt2d = r.caps.max_texture_dimension_2d,
+        bg   = r.caps.max_bind_groups,
+        mb   = r.get_vram_budget_bytes() / (1024*1024),
+    ))
 }
 
 /// Render heightmap to PNG
@@ -50,25 +57,28 @@ fn render_heightmap(
         (z.iter().map(|&x| x as f32).collect::<Vec<f32>>(), rows, cols)
     };
 
-    if sun_dir.len() != 3 {
+    if sun_dir.len() != 3 || !sun_dir.iter().all(|v| v.is_finite()) {
         return Err(VulkanRError::InvalidInput {
-            param: "sun_dir",
-            reason: "must have length 3".into(),
+            param: "sun_dir".into(),
+            reason: "must be length-3 finite numeric".into(),
         });
     }
-    let sun_dir_f32 = [sun_dir[0] as f32, sun_dir[1] as f32, sun_dir[2] as f32];
 
+    if width <= 0 || height <= 0 {
+        return Err(VulkanRError::InvalidInput {
+            param: "width/height".into(),
+            reason: "must be positive".into(),
+        });
+    }
+
+    let (w, h) = (width as u32, height as u32);
     let mut renderer = WgpuRenderer::new()?;
+    renderer.ensure_target_ok(w, h)?; // B1: guard BEFORE allocation
+
+    // continue with render, as before …
     renderer.render_heightmap(
-        path,
-        &z_data,
-        rows,
-        cols,
-        width as u32,
-        height as u32,
-        scale_z as f32,
-        fov_deg as f32,
-        sun_dir_f32,
+        path, &z_data, rows, cols, w, h, scale_z as f32, fov_deg as f32,
+        [sun_dir[0] as f32, sun_dir[1] as f32, sun_dir[2] as f32],
     )?;
     Ok(())
 }

--- a/tests/testthat/test-b1-validation.R
+++ b/tests/testthat/test-b1-validation.R
@@ -1,0 +1,37 @@
+test_that("input validation rejects bad shapes and values", {
+  z <- matrix(runif(4L*3L), 4L, 3L)
+  expect_error(
+    render_heightmap(tempfile(fileext=".png"), z, width=4L, height=3L),
+    class = "vkr_input"
+  )
+  z_bad <- z; z_bad[1,1] <- NA_real_
+  expect_error(render_heightmap(tempfile(fileext=".png"), z_bad, width=3L, height=4L),
+               class = "vkr_input")
+  expect_error(render_heightmap(tempfile(fileext=".png"), z, width=0L, height=4L),
+               class = "vkr_input")
+  expect_error(render_heightmap(tempfile(fileext=".png"), z, width=3L, height=4L, sun_dir=c(1,2)),
+               class = "vkr_input")
+})
+
+test_that("capability limit and VRAM budget are enforced", {
+  # This test assumes caps are typical (e.g., 4096 or 8192). Probe via gpu_info() string.
+  info <- gpu_info()
+  mt <- as.integer(sub(".*max_tex_2d: ([0-9]+).*", "\\1", info))
+  big <- mt + 1L
+  z <- matrix(runif(big * big), big, big)
+
+  expect_error(
+    render_heightmap(tempfile(fileext=".png"), z, width=big, height=big),
+    class = "vkr_caps"
+  )
+
+  # Budget test: force a tiny budget so even moderate sizes fail
+  withr::with_envvar(c(VULKANR_VRAM_BUDGET_MB="1"), {
+    w <- 2048L; h <- 2048L
+    z2 <- matrix(runif(w*h), h, w)
+    expect_error(
+      render_heightmap(tempfile(fileext=".png"), z2, width=w, height=h),
+      class = "vkr_oom"
+    )
+  })
+})


### PR DESCRIPTION
This commit introduces several key features for robustness and error handling:

1.  **GPU Capabilities Caching**: The renderer now queries and caches GPU device limits (e.g., `max_texture_dimension_2d`) upon initialization. This avoids redundant queries and makes the capabilities readily available.

2.  **Configurable VRAM Budget**: A VRAM budget is now enforced to prevent overallocating GPU memory. It defaults to 256MB and can be configured via the `VULKANR_VRAM_BUDGET_MB` environment variable.

3.  **Rust-side Pre-allocation Guards**: Before attempting to allocate the render target, the Rust code now checks if the requested dimensions exceed the device's capabilities or the available VRAM budget. This returns a classed error (`VulkanRError::Capability` or `VulkanRError::OutOfMemory`) with a descriptive message.

4.  **R-side Pre-FFI Validation**: The `render_heightmap` R function now performs comprehensive upfront validation of its arguments (e.g., checking for correct types, dimensions, and finite values) before calling into the Rust FFI. This provides clearer, faster feedback to the user for invalid inputs.

5.  **Improved Error Handling**: The R error handling has been improved to map the specific Rust errors to classed R conditions (`vkr_caps`, `vkr_oom`, `vkr_input`), allowing for more programmatic handling of errors.

6.  **Enhanced `gpu_info()`**: The `gpu_info()` function now reports the cached capabilities and VRAM budget.

7.  **Tests**: New unit tests have been added to verify the R-side input validation and the Rust-side capability and budget checks.